### PR TITLE
Upgrade for ruby-3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ruby:2.3
+FROM ruby:3.0
 MAINTAINER "Dave Long <dlong@cagedata.com>"
 
-ARG version=0.43.0
+ARG version=1.11.0
 
 RUN gem install rubocop -v ${version}
 


### PR DESCRIPTION
I think this branch should be in a tag ruby-3.0 or in a branch with the same name.

For now, you can use my image with

```
docker run --rm --volume "$PWD:/app" kalashnikovisme/docker-rubocop:ruby-3.0
```